### PR TITLE
Removed GlobalTimeout from template

### DIFF
--- a/sample-data/hello-world.tmpl
+++ b/sample-data/hello-world.tmpl
@@ -1,6 +1,5 @@
 version: '0.1'
 name: hello_world
-global_timeout: 60
 tasks:
 - name: "hello world"
   worker: "{{.worker_1}}"

--- a/sample-data/sample.tmpl
+++ b/sample-data/sample.tmpl
@@ -1,6 +1,5 @@
 version: '0.1'
 name: packet_osie_provision
-global_timeout: 600
 tasks:
 - name: "OS Installation"
   worker: "{{.worker_1}}"

--- a/src/client/workflow.go
+++ b/src/client/workflow.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strconv"
 	"time"
 
 	"github.com/gauravgahlot/tink-wizard/src/pkg/redis"
@@ -120,7 +119,6 @@ func getWorkflow(ctx context.Context, id string) (types.Workflow, error) {
 func setNameAndTimeout(wf *types.Workflow) {
 	details := *parseWorkflowYAML(wf.RawData)
 	wf.Name = details.Name
-	wf.Timeout = strconv.Itoa(details.GlobalTimeout)
 }
 
 func parseWorkflowYAML(data string) *types.WorkflowDetails {

--- a/src/pkg/types/workflow.go
+++ b/src/pkg/types/workflow.go
@@ -23,7 +23,6 @@ type WorkflowDetails struct {
 	Version       string `yaml:"version"`
 	Name          string `yaml:"name"`
 	ID            string `yaml:"id"`
-	GlobalTimeout int    `yaml:"global_timeout"`
 	Tasks         []Task `yaml:"tasks"`
 }
 


### PR DESCRIPTION
Signed-off-by: parauliya <aman@infracloud.io>

## Description

This PR will remove the global_timeout field from template which was unused.

## Why is this needed

Fixes: https://github.com/tinkerbell/tink/issues/198


## How are existing users impacted? What migration steps/scripts do we need?

Now the existing user need not to have `global_timeout` field in the template.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
